### PR TITLE
make it easier to run the test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ optional dependency. If installed, CLuck will take advantage of it. (For example
 `E-GRAPH-EQUALITY-SATURATE-NAIVE` will match different rewrite rules in parallel (though it still
 has to insert replacements in series)).
 
+## HACKING
+
+You can run the test suite by executing `(asdf:test-system "cluck")` if
+cluck is in asdf's source registry. Otherwise, you can `cl:load` the
+script `scripts/run-test.lisp`. It takes care of adding cluck's
+directory to asdf's source registry before calling
+`asdf:test-system`. Furthermore, from the command line, you can use `make`
+to run that script with sbcl.
+
 ## License
 
 MIT

--- a/cluck-tests.asd
+++ b/cluck-tests.asd
@@ -6,6 +6,9 @@
                :alexandria
                :fiasco
                :trivial-garbage)
+  :perform (test-op (op system)
+                    (symbol-call :fiasco '#:run-package-tests
+                                 :package '#:cluck/tests))
   :pathname "tests/"
   :serial t
   :components ((:file "package")

--- a/cluck.asd
+++ b/cluck.asd
@@ -1,10 +1,11 @@
 (asdf:defsystem :CLuck
   :description "Equivalence Graphs"
   :author "Mark Polyakov <mapolyakov@hrl.com>"
-  :license  "MIT"
+  :license "MIT"
   :version "0.0.1"
   :serial t
   :depends-on (:alexandria)
+  :in-order-to ((test-op (test-op "cluck-tests")))
   :components ((:file "package")
                (:file "utils")
                (:file "union-find")

--- a/makefile
+++ b/makefile
@@ -1,0 +1,4 @@
+
+.PHONY:
+test:
+	sbcl --non-interactive --disable-debugger --load 'scripts/run-tests.lisp'

--- a/scripts/run-tests.lisp
+++ b/scripts/run-tests.lisp
@@ -1,0 +1,16 @@
+
+(defpackage #:cluck.run-tests
+  (:documentation "Helper to run the tests from the command line.")
+  (:use #:cl))
+
+(in-package #:cluck.run-tests)
+
+(asdf:initialize-source-registry
+ `(:source-registry
+   (:directory ,(uiop:pathname-parent-directory-pathname *load-pathname*))
+   :inherit-configuration))
+
+;; for debugging
+;; (print (asdf:locate-system "cluck"))
+
+(asdf:test-system "cluck")


### PR DESCRIPTION
- add ":in-order-to test-op" to the system `cluck`
- add the corresponding ":perform test-op" to the `cluck-tests` system
- add a cl script to make it easier to run the tests regardless of where the project was cloned
- add a makefile as a simple entrypoint
- add a paragraph in the readme explaining how to run the tests